### PR TITLE
Step reversal

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -380,6 +380,7 @@ def review():
             d['field_defs'] = json.loads(row.field_defs.tobytes().decode('utf-8'))
         if row.status == 'matching ready':
             queue_count = queueCount(row.id)
+            print(queue_count)
             if queue_count == 0:
                 d['processing'] = True
         d['status_info'] = [i.copy() for i in STATUS_LIST if i['machine_name'] == row.status][0]

--- a/api/matching.py
+++ b/api/matching.py
@@ -206,39 +206,52 @@ def train():
 @check_sessions()
 def get_unmatched():
     session_id = request.args['session_id']
+    floor_it = False
 
-    # metadata for session
-    dedupe_session = db_session.query(DedupeSession).get(session_id)
-
-    fields = {f['field'] 
-              for f in 
-              json.loads(dedupe_session.field_defs.decode('utf-8'))}
-    fields.add('record_id')
-
-    # We have to check if there are any unseen records BEFORE polling
-    # records for review in order to avoid a race condition
-    unseen_records = unseenRecords(session_id)
-    raw_record, matched_records = pollHumanReview(session_id, fields)
-
-    if not matched_records :
-        if unseen_records :
-            response_message = 'filling human review'
-        else :
-            dedupe_session.status = 'canon clustered'
-            dedupeCanon.delay(session_id)
-
-    left_to_review = estimateRemainingReview(session_id)
-    dedupe_session.review_count = left_to_review
-    db_session.add(dedupe_session)
-    db_session.commit()
-
+    if request.args.get('floor_it') == 'true':
+        floor_it = True
+    
     resp = {
         'status': 'ok',
         'message': '',
     }
-    resp['object'] = raw_record
-    resp['matches'] = matched_records
-    resp['remaining'] = left_to_review
+    
+    # metadata for session
+    dedupe_session = db_session.query(DedupeSession).get(session_id)
+
+    if floor_it:
+        populateHumanReview.delay(session_id, floor_it=True)
+        dedupe_session.status = 'canon clustered'
+        dedupe_session.processing = True
+    
+    else:
+        fields = {f['field'] 
+                  for f in 
+                  json.loads(dedupe_session.field_defs.decode('utf-8'))}
+        fields.add('record_id')
+
+        # We have to check if there are any unseen records BEFORE polling
+        # records for review in order to avoid a race condition
+        unseen_records = unseenRecords(session_id)
+        raw_record, matched_records = pollHumanReview(session_id, fields)
+
+        if not matched_records :
+            if unseen_records :
+                response_message = 'filling human review'
+            else :
+                dedupe_session.status = 'canon clustered'
+                dedupe_session.processing = True
+                dedupeCanon.delay(session_id)
+
+        left_to_review = estimateRemainingReview(session_id)
+        dedupe_session.review_count = left_to_review
+        
+        resp['object'] = raw_record
+        resp['matches'] = matched_records
+        resp['remaining'] = left_to_review
+    
+    db_session.add(dedupe_session)
+    db_session.commit()
 
     return jsonResponse(resp)
 
@@ -306,6 +319,7 @@ def pollHumanReview(session_id, fields) :
     raw_record, matches = matchRowsToDict(matched_records)
 
     dedupe_session = db_session.query(DedupeSession).get(session_id)
+
     if queueCount(session_id) <= 10 and not dedupe_session.processing:
         populateHumanReview.delay(session_id)
 
@@ -342,7 +356,7 @@ def estimateRemainingReview(session_id) :
 
     unseen = unseenRecords(session_id)
     queue_count = queueCount(session_id)
-
+    
     remaining_count = round(unseen * upper_proportion) + queue_count
 
     print(remaining_count, unseen, proportion, std_err)

--- a/api/review.py
+++ b/api/review.py
@@ -97,9 +97,10 @@ def get_canon_cluster():
         resp['false_negative'] = false_neg
     else:
         dedupe_session.processing = True
+        dedupe_session.status = 'canonical'
         db_session.add(dedupe_session)
         db_session.commit()
-        dedupeCanon.delay(session_id)
+        flash("Hooray! '%s' is now canonical!" % dedupe_session.name, 'success')
     resp['total_clusters'] = dedupe_session.entity_count
     resp['review_remainder'] = dedupe_session.review_count
 

--- a/api/review.py
+++ b/api/review.py
@@ -66,7 +66,7 @@ def get_cluster():
         dedupe_session.processing = True
         db_session.add(dedupe_session)
         db_session.commit()
-        dedupeCanon.delay(dedupe_session.id)
+        getMatchingReady.delay(dedupe_session.id)
     resp['total_clusters'] = dedupe_session.entity_count
     resp['review_remainder'] = dedupe_session.review_count
 
@@ -99,7 +99,7 @@ def get_canon_cluster():
         dedupe_session.processing = True
         db_session.add(dedupe_session)
         db_session.commit()
-        getMatchingReady.delay(session_id)
+        dedupeCanon.delay(session_id)
     resp['total_clusters'] = dedupe_session.entity_count
     resp['review_remainder'] = dedupe_session.review_count
 

--- a/api/templates/dedupe_session/match-review.html
+++ b/api/templates/dedupe_session/match-review.html
@@ -8,12 +8,37 @@
         <p>Below is a single record that doesn't belong to any entity. Match it to one or more of the entities below. If it doesn't belong with any of them, skip it and move on.</p>
 
         <div id="group-display"></div>
-        <div id="review-buttons">
-            <button class="btn btn-info" id="mark-match">
-                None of these match &raquo;
-            </button>
+        <div class="row">
+            <div class="col-md-8">
+                <div id="review-buttons">
+                    <button class="btn btn-info" id="mark-match">
+                        None of these match &raquo;
+                    </button>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <button class="btn btn-link" id="accept-confirm" data-toggle="modal" data-target="#confirm-modal">
+                    <i class='fa fa-check'></i>
+                    Accept the remaining matches &raquo;
+                </button>
+            </div>
         </div>
     </div>
+    <div id="confirm-modal" class="modal fade">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                    <p class="modal-title">Are you sure you want to accept the remaining matches?</p>
+                    <p id='uncertain_modal'></p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-link" data-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" data-dismiss="modal" id="accept-all"><i class='fa fa-check'></i> Accept</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
 {% endblock %}
 {% block extra_javascript %}
 <script src="{{ url_for('static', filename='js/spin.min.js') }}"></script>
@@ -23,7 +48,7 @@
     <div class='row'>
         <div class='col-md-4'>
         <h4 id='review-count' data-content="This is an estimate of the number of records we need you to review based on what you've matched so far. The more you review, the more accurate it will be." rel="popover" data-placement="top" data-trigger="hover">
-            Uncertain records left: 
+            Uncertain records left:
             <% if (remaining < 5) { %>
                 <strong><5</strong>
             <% } else { %>
@@ -77,7 +102,7 @@
     var match_obj;
     var matches;
     $(document).ready(function(){
-        getAndMatch();
+        getAndMatch(false);
         $('#mark-match').on('click', function(e){
             var data = {
                 'api_key': api_key,
@@ -102,20 +127,28 @@
             data['session_id'] = session_id
             $.when(addTraining(JSON.stringify(data))).then(
                 function(resp){
-                    getAndMatch();
+                    getAndMatch(false);
                 }
             )
         });
+        $('#accept-all').on('click', function(e){
+            getAndMatch(true);
+        })
     });
-    function getAndMatch(){
+    function getAndMatch(floor_it){
         $('#group-display').spin('large')
-        $.when(getRecord()).then(function(resp){
+        $.when(getRecord(floor_it)).then(function(resp){
             $('#group-display').spin(false);
             match_obj = resp['object'];
             matches = resp['matches'];
             remaining = parseInt(resp['remaining'])
             if (typeof match_obj !== 'undefined' && !$.isEmptyObject(match_obj)){
                 displayRecord(resp.matches, resp.object, remaining)
+            } else if (floor_it){
+                $('#group-display').spin(false);
+                $('#group-display').html('<h2>Accepting the rest ...</h2>');
+                $('#review-buttons').hide();
+                window.location = '/'
             } else {
                 $('#group-display').spin(false);
                 $('#group-display').html('<h2>Matching complete</h2>');
@@ -141,8 +174,8 @@
                 $('#mark-match').html("None of these match &raquo;");
         });
     }
-    function getRecord(){
-        return $.getJSON('/get-unmatched-record/?session_id=' + session_id)
+    function getRecord(floor_it){
+        return $.getJSON('/get-unmatched-record/?session_id=' + session_id + '&floor_it=' + floor_it)
     }
     function addTraining(data){
         return $.ajax({

--- a/api/templates/session-admin.html
+++ b/api/templates/session-admin.html
@@ -193,7 +193,7 @@
                             </select>
                         </td>
                     </tr>
-                    {% if dedupe_session.status in ['canon clustered', 'matching ready', 'canonical'] %}
+                    {% if dedupe_session.status in ['canon clustered', 'canonical'] %}
                     <tr>
                         <td>
                             <a class='btn btn-info btn-sm clustering' href="javascript://" data-step="second">

--- a/api/utils/delayed_tasks.py
+++ b/api/utils/delayed_tasks.py
@@ -55,7 +55,7 @@ def bulkMarkClusters(session_id, user=None):
         parent_entities = c.execute(update_parents, **upd_vals)
     
     updateEntityCount(session_id)
-    dedupeCanon(session_id)
+    getMatchingReady(session_id)
 
 @queuefunc
 def bulkMarkCanonClusters(session_id, user=None):
@@ -78,7 +78,6 @@ def bulkMarkCanonClusters(session_id, user=None):
                 '''.format(session_id)),
                 target=row[0], record_id=row[1])
     updateEntityCount(session_id)
-    getMatchingReady(session_id)
 
 def updateFromCanon(session_id):
     return text(''' 

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -54,20 +54,20 @@ STATUS_LIST = [
         'next_step': 3
     },
     {
-        'step': 4,
+        'step': 5,
         'machine_name': 'canon clustered',
         'human_name': 'Entities reviewed', 
-        'next_step_name': 'Merge entities',
+        'next_step_name': 'Final review',
         'next_step_url': '/session-review/?session_id={0}&second_review=True',
-        'next_step': 5
+        'next_step': 6
     },
     {
-        'step': 5,
+        'step': 4,
         'machine_name': 'matching ready',
         'human_name': 'Entities merged', 
-        'next_step_name': 'Final review',
+        'next_step_name': 'Matching review',
         'next_step_url': '/match-review/?session_id={0}',
-        'next_step': 6
+        'next_step': 5
     },
     {
         'step': 6,

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -250,7 +250,7 @@ class AdminTest(DedupeAPITestCase):
         
         bulkMarkClusters(self.dd_sess.id)
         db_session.refresh(self.dd_sess)
-        assert self.dd_sess.status == 'canon clustered'
+        assert self.dd_sess.status == 'matching ready'
         
         with self.app.test_request_context():
             self.login()

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -60,7 +60,6 @@ class MatchingTest(unittest.TestCase):
         initializeModel(cls.dd_sess.id)
         dedupeRaw(cls.dd_sess.id)
         bulkMarkClusters(cls.dd_sess.id, user=cls.user.name)
-        bulkMarkCanonClusters(cls.dd_sess.id, user=cls.user.name)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -3,7 +3,8 @@ from os.path import join, abspath, dirname
 from flask import request, session
 from sqlalchemy import text
 from api.utils.delayed_tasks import initializeSession, initializeModel, \
-    dedupeRaw, bulkMarkClusters, bulkMarkCanonClusters
+    dedupeRaw, bulkMarkClusters, bulkMarkCanonClusters, getMatchingReady, \
+    populateHumanReview
 from tests import DedupeAPITestCase
 from api.utils.helpers import slugify
 from api.database import app_session as db_session
@@ -44,6 +45,8 @@ class ReviewTest(DedupeAPITestCase):
         entity_table = 'entity_{0}'.format(self.dd_sess.id)
         if canonical:
             bulkMarkClusters(self.dd_sess.id, user=self.user.name)
+            getMatchingReady(self.dd_sess.id)
+            populateHumanReview(self.dd_sess.id, floor_it=True)
             endpoints = {
                 'get': '/get-canon-review-cluster/?session_id={0}'.format(self.dd_sess.id),
                 'mark_one': '/mark-canon-cluster/?session_id={0}'.format(self.dd_sess.id),

--- a/tests/test_track_usage.py
+++ b/tests/test_track_usage.py
@@ -59,7 +59,6 @@ class TrackUsageTest(unittest.TestCase):
         initializeModel(cls.dd_sess.id)
         dedupeRaw(cls.dd_sess.id)
         bulkMarkClusters(cls.dd_sess.id, user=cls.user.name)
-        bulkMarkCanonClusters(cls.dd_sess.id, user=cls.user.name)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Reverses the order of the merge entities and matching review steps. Also adds a way to bulk accept the matching review by just looping through the rest of the matches that are found and auto accepting them.

Closes #191 
Closes #195 